### PR TITLE
feat: add protobuf for DNS configuration

### DIFF
--- a/.conform.yaml
+++ b/.conform.yaml
@@ -1,0 +1,26 @@
+policies:
+  - type: commit
+    spec:
+      dco: true
+      gpg: false
+      spellcheck:
+        locale: US
+      maximumOfOneCommit: true
+      header:
+        length: 89
+        imperative: true
+        case: lower
+        invalidLastCharacters: .
+      body:
+        required: true
+      conventional:
+        types:
+          - chore
+          - docs
+          - perf
+          - refactor
+          - style
+          - test
+          - release
+        scopes:
+          - spec

--- a/api.proto
+++ b/api.proto
@@ -1,0 +1,43 @@
+syntax = "proto3";
+
+package api;
+
+service ResolverService {
+  rpc Apply(ApplyRequest)
+      returns (ApplyResponse);
+}
+
+message ApplyRequest {
+  SystemResolver resolver = 1;
+}
+
+message ApplyResponse {}
+
+// SystemResolver provides configuration options for the system resolver.
+//
+// https://man7.org/linux/man-pages/man5/resolv.conf.5.html.
+message SystemResolver{
+  repeated string nameserver = 1;
+  string search = 2;
+  repeated string sortlist = 3;
+  repeated SystemResolverOptions options = 4;
+}
+
+message SystemResolverOptions{
+  bool debug = 1;
+  uint32 ndots = 2;
+  uint32 timeout = 3;
+  uint32 attempts = 4;
+  bool rotate = 5;
+  bool no_check_names = 6;
+  bool inet6 = 7;
+  bool ip6_bytestring = 8;
+  bool ip6_dotint = 9;
+  bool edns0 = 10;
+  bool single_request = 11;
+  bool single_request_reopen = 12;
+  bool no_tld_query = 13;
+  bool use_vc = 14;
+  bool no_reload = 15;
+  bool trust_ad = 16;
+}


### PR DESCRIPTION
This adds a protobuf for the resolver configuration file (i.e. `/etc/resolv.conf`).

Signed-off-by: Andrew Rynhard <andrew@rynhard.io>