### PR TITLE
feat: update api for etcd backend implementation

### DIFF
--- a/proto/v1alpha1/runtime.proto
+++ b/proto/v1alpha1/runtime.proto
@@ -290,17 +290,22 @@ message RuntimeCreateRequest {
 }
 
 message RuntimeCreateResponse {
+    resource.Resource resource = 1;
 }
 
 // Update RPC
 
 message RuntimeUpdateRequest {
     string controller_token = 1;
-    string current_version = 2;
+
+    reserved 2;
+    reserved "current_version";
+
     resource.Resource new_resource = 3;
 }
 
 message RuntimeUpdateResponse {
+    resource.Resource resource = 1;
 }
 
 // Teardown RPC

--- a/proto/v1alpha1/state.proto
+++ b/proto/v1alpha1/state.proto
@@ -102,12 +102,15 @@ message CreateOptions {
 }
 
 message CreateResponse {
+    resource.Resource resource = 1;
 }
 
 // Update RPC
 
 message UpdateRequest {
-    string current_version = 1;
+    reserved 1;
+    reserved "current_version";
+
     resource.Resource new_resource = 2;
 
     UpdateOptions options = 3;
@@ -119,6 +122,7 @@ message UpdateOptions {
 }
 
 message UpdateResponse {
+    resource.Resource resource = 1;
 }
 
 // Destroy RPC


### PR DESCRIPTION
Contains the following changes:
- Removes current_version field on update requests: The resource definition already contains the version on its metadata, so the current_version argument is redundant. This is a breaking change.
- Adds resource to the create and update API responses, so that any changes done by the backend can be reflected on the API consumer side.

Signed-off-by: Utku Ozdemir <utku.ozdemir@siderolabs.com>