### PR TITLE
feat: support aggregated Watch responses

### DIFF
--- a/proto/v1alpha1/state.proto
+++ b/proto/v1alpha1/state.proto
@@ -166,8 +166,9 @@ message WatchOptions {
     int32 tail_events = 2;
     resource.LabelQuery label_query = 3;
     resource.IDQuery id_query = 4;
+    bool aggregated = 5;
 }
 
 message WatchResponse {
-    Event event = 1;
+    repeated Event event = 1;
 }


### PR DESCRIPTION
If enabled, multiple events might be returned in a single response message. This increases throughput of Watch operations.