### PR TITLE
feat: add watch response API version

### DIFF
--- a/proto/v1alpha1/state.proto
+++ b/proto/v1alpha1/state.proto
@@ -173,4 +173,9 @@ message WatchOptions {
 
 message WatchResponse {
     repeated Event event = 1;
+
+    // Suppprted API versions:
+    // 0 (not set): doesn't support watch bookmarks
+    // 1: supports watch bookmarks
+    int32 api_version = 2;
 }


### PR DESCRIPTION
Allows for a protobuf client to figure out if the server supports watch bookmarks (if watches can be restarted).